### PR TITLE
Userの削除,Team edit制限

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -31,8 +31,6 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assigned_user != current_user && assign.team.owner != current_user
-      "他のユーザーは削除できません"
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -31,7 +31,7 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assigned_user != current_user && assign.team.owner
+    elsif assigned_user != current_user && assign.team.owner != current_user
       "他のユーザーは削除できません"
     elsif assign.destroy
       set_next_team(assign, assigned_user)

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -31,6 +31,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif assigned_user != current_user && assign.team.owner
+      "他のユーザーは削除できません"
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -17,6 +17,7 @@ class TeamsController < ApplicationController
 
   def edit; end
 
+
   def create
     @team = Team.new(team_params)
     @team.owner = current_user

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
+            <% if current_user == @team.owner %>
             <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -43,9 +43,10 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <% unless assign.user != current_user && assign.team.owner != current_user %>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                      <% end %>
+                      <td><% unless assign.user != current_user && assign.team.owner != current_user %>
+                        <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -43,7 +43,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
+                      <% unless assign.user != current_user && assign.team.owner != current_user %>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -43,7 +43,7 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><% unless assign.user != current_user && assign.team.owner != current_user %>
+                      <td><% if assign.user == current_user || assign.team.owner == current_user %>
                         <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
                         <% end %>
                       </td>


### PR DESCRIPTION
- Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

- TeamのeditはTeamのリーダー（オーナー）のみができるようにすること