### PR TITLE
Feature/issues 65チームリーダーが、他のチームメンバーにリーダー権限を渡せる機能を実装すること

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -53,6 +53,7 @@ class TeamsController < ApplicationController
     change_user_id = Assign.find(assign_id).user_id
     # binding.pry
     @team.update(owner_id: change_user_id)
+    TeamMailer.team_mail(@team).deliver
     redirect_to team_url(@team), notice: 'チームリーダーを変更しました'
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy leader_change]
 
   def index
     @teams = Team.all
@@ -46,6 +46,14 @@ class TeamsController < ApplicationController
 
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
+  end
+
+  def leader_change
+    assign_id = params[:assign_id]
+    change_user_id = Assign.find(assign_id).user_id
+    # binding.pry
+    @team.update(owner_id: change_user_id)
+    redirect_to team_url(@team), notice: 'チームリーダーを変更しました'
   end
 
   private

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -1,0 +1,6 @@
+class TeamMailer < ApplicationMailer
+  def team_mail(team)
+    @team = team
+    mail to: @team.owner.email, subject: 'リーダー変更通知'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,5 @@ class User < ApplicationRecord
   def self.generate_password
     SecureRandom.hex(10)
   end
+  
 end

--- a/app/views/team_mailer/team_mail.html.erb
+++ b/app/views/team_mailer/team_mail.html.erb
@@ -1,0 +1,4 @@
+<h3>チームリーダーがあなたへ変更されました</h3>
+<h4>詳細は下記の通りです。</h4>
+<p>Team: <%= @team.name %></p>
+<p>Email: <%= @team.owner.email %></p>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -47,6 +47,11 @@
                         <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
                         <% end %>
                       </td>
+                      <td>
+                        <% if assign.team.owner == current_user && !(assign.user_id == @team.owner_id) %>
+                        <%= link_to '権限移動' , leader_change_team_path(@team, assign_id: assign.id), method: :patch, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,11 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
+    member do
+      patch 'leader_change'
+    end
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do

--- a/spec/mailers/previews/team_mailer_preview.rb
+++ b/spec/mailers/previews/team_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_mailer
+class TeamMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_mailer_spec.rb
+++ b/spec/mailers/team_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する 

- そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される

- アクションはTeamコントローラに任意のものを追加する

- Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ

- 情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）

- その他、アプリケーションの挙動に不審な点やエラーがないこと