### PR TITLE
Feature/issues 67アジェンダの削除機能を実装すること

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development do
   gem 'listen', '~> 3.0.5'
   gem 'rack-mini-profiler', require: false
   gem 'web-console', '>= 3.3.0'
+  gem 'brakeman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
+    brakeman (4.9.0)
     builder (3.2.4)
     bullet (6.1.0)
       activesupport (>= 3.0.0)
@@ -390,6 +391,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
+  brakeman
   bullet
   byebug
   capistrano

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -24,6 +24,7 @@ class AgendasController < ApplicationController
 
   def destroy
     @agenda.destroy
+    AgendaMailer.agenda_mail(@agenda).deliver
     redirect_to dashboard_url, notice: 'アジェンダを削除しました'
   end
 

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,6 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  # before_action :set_agenda, only: %i[show edit update]
+  before_action :set_agenda, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +16,15 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url, notice: 'アジェンダを削除しました'
   end
 
   private

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,7 @@
+class AgendaMailer < ApplicationMailer
+  def agenda_mail(agenda)
+    @agenda = agenda
+    @users = @agenda.team.users
+    mail to: @users.map(&:email), subject: 'アジェンダ削除完了通知'
+  end
+end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,7 +1,6 @@
 class AgendaMailer < ApplicationMailer
   def agenda_mail(agenda)
     @agenda = agenda
-    @users = @agenda.team.users
-    mail to: @users.map(&:email), subject: 'アジェンダ削除完了通知'
+    mail to: @agenda.team.members.map(&:email), subject: 'アジェンダ削除完了通知'
   end
 end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,4 @@
+<h3>下記アジェンダが削除されました</h3>
+<h4>詳細は下記の通りです。</h4>
+<p>Team: <%= @agenda.team.name %></p>
+<p>Agenda: <%= @agenda.title %></p>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -14,7 +14,7 @@
       </div>
       <!-- /.card-header -->
       <div class="card-body">
-        <%= markdown(@article.content).html_safe %>
+        <%= sanitize markdown(@article.content).html_safe %>
         <%= image_tag @article.image_url if @article.image_url %>
       </div>
 

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,6 +37,7 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+              <%= link_to '削除', agenda_path(agenda), method: :delete %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,7 +37,7 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
-              <% if agenda.user == current_user || agenda.team.owner == current_user %>
+              <% if agenda.user == current_user %>
               <%= link_to '削除', agenda_path(agenda), method: :delete, class:'nav-link d-inline-flex' %>
               <% end %>
             <ul class="nav nav-treeview" style="display: block;">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,14 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
-              <i class="fa fa-circle-o nav-icon"></i>
+            <a href="#" class="nav-link d-inline-flex" style="width:70%;">
+              <!-- <i class="fa fa-circle-o nav-icon"></i> -->
               <p>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
-              <%= link_to '削除', agenda_path(agenda), method: :delete %>
+              <%= link_to '削除', agenda_path(agenda), method: :delete, class:'nav-link d-inline-flex' %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,7 +37,9 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+              <% if agenda.user == current_user || agenda.team.owner == current_user %>
               <%= link_to '削除', agenda_path(agenda), method: :delete, class:'nav-link d-inline-flex' %>
+              <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,7 +37,7 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
-              <% if agenda.user == current_user %>
+              <% if agenda.user == current_user || agenda.team.owner == current_user %>
               <%= link_to '削除', agenda_path(agenda), method: :delete, class:'nav-link d-inline-flex' %>
               <% end %>
             <ul class="nav nav-treeview" style="display: block;">

--- a/output.html
+++ b/output.html
@@ -1,0 +1,238 @@
+<!DOCTYPE HTML SYSTEM>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<title>Brakeman Report</title>
+  <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+  <script type="text/javascript" src="https://cdn.datatables.net/1.10.9/js/jquery.dataTables.min.js"></script>
+  <script type="text/javascript">
+    function toggle(context) {
+      var elem = document.getElementById(context);
+
+      if (elem.style.display != "block")
+        elem.style.display = "block";
+      else
+        elem.style.display = "none";
+
+      elem.parentNode.scrollIntoView();
+    }
+
+    $(document).ready(function() {
+      $('table').DataTable({
+        searching: false,
+        paging:    false,
+        info:      false
+      });
+    });
+  </script>
+  <style>
+    /* CSS style used for HTML reports */
+
+body {
+  font-family: sans-serif;
+  color: #161616;
+}
+
+a {
+  color: #161616;
+}
+
+p {
+  font-weight: bold;
+  font-size: 11pt;
+  color: #2D0200;
+ }
+
+ th {
+   background-color: #980905;
+   border-bottom: 5px solid #530200;
+   color: white;
+   font-size: 11pt;
+   padding: 1px 8px 1px 8px;
+ }
+
+ td {
+   border-bottom: 2px solid white;
+   font-family: monospace;
+   padding: 5px 8px 1px 8px;
+ }
+
+ table {
+   background-color: #FCF4D4;
+   border-collapse: collapse;
+ }
+
+ h1 {
+   color: #2D0200;
+   font-size: 14pt;
+ }
+
+ h2 {
+   color: #2D0200;
+   font-size: 12pt;
+ }
+
+ span.high-confidence {
+   font-weight:bold;
+   color: red;
+ }
+
+ span.med-confidence {
+ }
+
+ span.weak-confidence {
+   color:gray;
+ }
+
+ div.warning_message {
+   cursor: pointer;
+ }
+
+ div.warning_message:hover {
+   background-color: white;
+ }
+
+ table caption {
+   background-color: #FFE;
+   padding: 2px;
+ }
+
+ table.context {
+   margin-top: 5px;
+   margin-bottom: 5px;
+   border-left: 1px solid #90e960;
+   color: #212121;
+ }
+
+ tr.context {
+   background-color: white;
+ }
+
+ tr.first {
+   border-top: 1px solid #7ecc54;
+   padding-top: 2px;
+ }
+
+ tr.error {
+  background-color: #f4c1c1 !important
+ }
+
+ tr.near_error {
+  background-color: #f4d4d4 !important
+ }
+
+ tr.alt {
+   background-color: #e8f4d4;
+ }
+
+ td.context {
+   padding: 2px 10px 0px 6px;
+   border-bottom: none;
+ }
+
+ td.context_line {
+   padding: 2px 8px 0px 7px;
+   border-right: 1px solid #b3bda4;
+   border-bottom: none;
+   color: #6e7465;
+ }
+
+ pre.context {
+   margin-bottom: 1px;
+ }
+
+ .user_input {
+   background-color: #fcecab;
+ }
+
+ div.render_path {
+   display: none;
+   background-color: #ffe;
+   padding: 5px;
+   margin: 2px 0px 2px 0px;
+ }
+
+ div.template_name {
+   cursor: pointer;
+ }
+
+ div.template_name:hover {
+   background-color: white;
+ }
+
+ span.code {
+   font-family: monospace;
+ }
+
+ span.filename {
+   font-family: monospace;
+ }
+
+  </style>
+</head>
+<body>
+
+<h1>Brakeman Report</h1>
+<table>
+  <thead>
+    <tr>
+      <th>Application Path</th>
+      <th>Rails Version</th>
+      <th>Brakeman Version</th>
+      <th>Report Time</th>
+      <th>Checks Performed</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>/Users/kusanoasaki/boostrap/diveintopost</td>
+      <td>5.2.4.3</td>
+      <td>4.9.0
+      <td>
+        2020-08-29 16:54:23 +0900<br><br>
+        0.477121 seconds
+      </td>
+      <td>BasicAuth, BasicAuthTimingAttack, CSRFTokenForgeryCVE, ContentTag, CookieSerialization, CreateWith, CrossSiteScripting, DefaultRoutes, Deserialize, DetailedExceptions, DigestDoS, DynamicFinders, EscapeFunction, Evaluation, Execute, FileAccess, FileDisclosure, FilterSkipping, ForgerySetting, HeaderDoS, I18nXSS, JRubyXML, JSONEncoding, JSONEntityEscape, JSONParsing, LinkTo, LinkToHref, MailTo, MassAssignment, MimeTypeDoS, ModelAttrAccessible, ModelAttributes, ModelSerialize, NestedAttributes, NestedAttributesBypass, NumberToCurrency, PageCachingCVE, PermitAttributes, QuoteTableName, Redirect, RegexDoS, Render, RenderDoS, RenderInline, ResponseSplitting, RouteDoS, SQL, SQLCVEs, SSLVerify, SafeBufferManipulation, SanitizeMethods, SelectTag, SelectVulnerability, Send, SendFile, SessionManipulation, SessionSettings, SimpleFormat, SingleQuotes, SkipBeforeFilter, SprocketsPathTraversal, StripTags, SymbolDoSCVE, TemplateInjection, TranslateBug, UnsafeReflection, ValidationRegex, WithoutProtection, XMLDoS, YAMLParsing</td>
+    </tr>
+  </tbody>
+</table>
+<br>
+<h2 id='summary'>Summary</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Scanned/Reported</th>
+      <th>Total</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Controllers</td>
+      <td>14</td>
+    </tr>
+    <tr>
+      <td>Models</td>
+      <td>8</td>
+    </tr>
+    <tr>
+      <td>Templates</td>
+      <td>44</td>
+    </tr>
+    <tr>
+      <td>Errors</td>
+      <td>0</td>
+    </tr>
+    <tr>
+      <td>Security Warnings</td>
+      <td>0 <span class='high-confidence'>(0)</span></td>
+    </tr>
+  
+    <tr>
+      <td>Ignored Warnings</td>
+      <td>0</td>
+    </tr>
+  
+  </tbody>
+</table>
+<br>
+</body></html>

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
- AgendasControllerのdestroyアクションを追加し、そこに機能追加する

- Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される

- Agendaに紐づいているarticleも一緒に削除される

- Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ

- Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ

- 情報処理が完了した後はDashBoardに飛ぶ